### PR TITLE
SIGHUP handler for reloading config

### DIFF
--- a/engine/engine.c
+++ b/engine/engine.c
@@ -87,6 +87,11 @@ static int default_parse_option (int val) {
 
 /* {{{ SIGNAL ACTIONS */
 static void default_sighup (void) {
+  int res = do_reload_config (0x4);
+
+  if (res < 0) {
+    fprintf (stderr, "config check failed! (code %d)\n", res);
+  }
 }
 
 static void default_sigusr1 (void) {


### PR DESCRIPTION
Adds `SIGHUP` handler for on the fly config reload. Fixes #46.

To check, `kill -s HUP <mtproxy-pid>`.

Then in e.g. SystemD service, add:
```
[Service]
...
ExecReload=/bin/kill -s HUP $MAINPID
```
Result is being able to reload config after updating proxy file via systemctl reload mtproxy.

[Upstream](https://github.com/TelegramMessenger/MTProxy/pull/316)